### PR TITLE
remove meetup, use lu.ma

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
 						<nav>
 							<ul>
 									<li><a target="_blank" href="https://clojure.tw/weekly" class="icon fa-file-text-o"><span class="label">Weekly News</span></a></li>
-									<li><a target="_blank" href="http://www.meetup.com/Clojure-tw/" class="icon fa-meetup"><span class="label">Meetup</span></a></li>
+									<li><a target="_blank" href="https://lu.ma/clojuretw" class="icon fa-calendar"><span class="label">Meetup</span></a></li>
 									<li><a target="_blank" href="https://twitter.com/clojuretw" class="icon fa-twitter"><span class="label">Twitter</span></a></li>
 									<li><a target="_blank" href="https://t.me/clojuretw" class="icon fa-telegram"><span class="label">Telegram</span></a></li>
 									<li><a target="_blank" href="https://github.com/clojure-tw" class="icon fa-github"><span class="label">Github</span></a></li>
@@ -42,7 +42,7 @@
 				<!-- Footer -->
 					<footer id="footer">
 							<!-- <span class="copyright">&copy; 2018 Clojure Taiwan Community. Theme designed by: <a href="http://html5up.net">HTML5 UP</a>.</span> -->
-							<span class="copyright">&copy; 2022 Clojure Taiwan Community</span>
+							<span class="copyright">&copy; 2025 Clojure Taiwan Community</span>
 					</footer>
 
 			</div>


### PR DESCRIPTION
- 更新到 2025
- 移除 meetup 的 icon link，因為我們日後不使用 meetup 了。
- 建立 lu.ma 的 icon link ，因為日後改用 https://lu.ma/clojuretw